### PR TITLE
bug fix to counting total number of data points in TracrBenchmarkCase

### DIFF
--- a/circuits_benchmark/benchmark/tracr_benchmark_case.py
+++ b/circuits_benchmark/benchmark/tracr_benchmark_case.py
@@ -210,10 +210,10 @@ class TracrBenchmarkCase(BenchmarkCase):
     """Returns the total number of possible sequences for the vocab and sequence lengths."""
     vals = sorted(list(self.get_vocab()))
     max_len = self.get_max_seq_len()
-    min_len = self.get_min_seq_len()
+    min_len = self.get_min_seq_len() - 1
 
     total_len = 0
-    for l in range(min_len, max_len + 1):
+    for l in range(min_len, max_len):
       total_len += len(vals) ** l
 
     return total_len


### PR DESCRIPTION
Title says it all -- noticed a discrepancy between the real number of points in the case 3 dataset and the number of points reported by this function.

Found this by comparing:

```
total_data = task.get_total_data_len()
input_data, output_data = task.gen_all_data(task.get_min_seq_len(), task.get_max_seq_len())
```