### PR TITLE
iit.model_pairs.nodes -> iit.utils.nodes

### DIFF
--- a/circuits_benchmark/benchmark/cases/case_ioi.py
+++ b/circuits_benchmark/benchmark/cases/case_ioi.py
@@ -1,7 +1,7 @@
 from typing import Optional, Callable
 
 import torch as t
-from iit.model_pairs.nodes import LLNode
+from iit.utils.nodes import LLNode
 from jaxtyping import Float
 from torch import Tensor
 from transformer_lens import HookedTransformer, HookedTransformerConfig

--- a/circuits_benchmark/commands/evaluation/realism/gt_circuit_node_wise_ablation.py
+++ b/circuits_benchmark/commands/evaluation/realism/gt_circuit_node_wise_ablation.py
@@ -15,7 +15,7 @@ from circuits_benchmark.transformers.hooked_tracr_transformer import HookedTracr
 from circuits_benchmark.utils.iit._acdc_utils import get_gt_circuit
 from circuits_benchmark.utils.iit.iit_hl_model import IITHLModel
 from iit.model_pairs.iit_behavior_model_pair import IITBehaviorModelPair
-from iit.model_pairs.nodes import LLNode
+from iit.utils.nodes import LLNode
 from iit.utils import index, IITDataset
 from iit.utils.eval_ablations import get_mean_cache, get_circuit_score
 from circuits_benchmark.utils.ll_model_loader.ll_model_loader_factory import LLModelLoader, get_ll_model_loader_from_args

--- a/circuits_benchmark/commands/evaluation/realism/node_wise_ablation.py
+++ b/circuits_benchmark/commands/evaluation/realism/node_wise_ablation.py
@@ -14,7 +14,7 @@ from circuits_benchmark.utils.iit.iit_hl_model import IITHLModel
 from circuits_benchmark.utils.iit.wandb_loader import load_circuit_from_wandb
 from circuits_benchmark.utils.ll_model_loader.ll_model_loader_factory import LLModelLoader, get_ll_model_loader_from_args
 from iit.model_pairs.iit_behavior_model_pair import IITBehaviorModelPair
-from iit.model_pairs.nodes import LLNode
+from iit.utils.nodes import LLNode
 from iit.utils import IITDataset, index
 from iit.utils.eval_ablations import get_circuit_score, get_mean_cache
 

--- a/circuits_benchmark/utils/iit/_acdc_utils.py
+++ b/circuits_benchmark/utils/iit/_acdc_utils.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from circuits_benchmark.benchmark.benchmark_case import BenchmarkCase
 from circuits_benchmark.utils.circuit.circuit import Circuit, CircuitNode
-from iit.model_pairs.nodes import LLNode
+from iit.utils.nodes import LLNode
 from iit.utils import index
 from iit.utils.correspondence import Correspondence
 from circuits_benchmark.utils.circuit.prepare_circuit import prepare_circuit_for_evaluation

--- a/circuits_benchmark/utils/iit/correspondence.py
+++ b/circuits_benchmark/utils/iit/correspondence.py
@@ -1,7 +1,7 @@
 import pickle
 from typing import Dict, Set, Tuple, Optional, Literal
 
-from iit.model_pairs.nodes import LLNode, HLNode
+from iit.utils.nodes import LLNode, HLNode
 from iit.utils import index
 from iit.utils.correspondence import Correspondence
 from iit.utils.index import TorchIndex

--- a/circuits_benchmark/utils/iit/tracr_hl_node.py
+++ b/circuits_benchmark/utils/iit/tracr_hl_node.py
@@ -1,4 +1,4 @@
-from iit.model_pairs import HLNode
+from iit.utils.nodes import HLNode
 from iit.utils import index
 
 from circuits_benchmark.utils.circuit.circuit_node import CircuitNode


### PR DESCRIPTION
In an IIT PR (https://github.com/cybershiptrooper/iit/pull/15), I fixed a circular import by moving the nodes definitions into utils from the model_pairs tree. If that PR gets merged, this PR will keep circuits-bench from breaking by relocating node imports.